### PR TITLE
Fix to first/last kmer edge case in DBGBloomAlgorithms.h for Sealer

### DIFF
--- a/subprojects/sealer/Konnector/DBGBloomAlgorithms.h
+++ b/subprojects/sealer/Konnector/DBGBloomAlgorithms.h
@@ -96,9 +96,9 @@ static inline unsigned getStartKmerPos(const Sequence& seq,
 
 	/* handle case where first/last kmer in seq is a match */
 	if (matchCount > maxMatchLen) {
-		assert(nthash.get_pos() - 1 >= 0 &&
-			nthash.get_pos() - 1 < (int)(seq.length() - k + 1));
-		maxMatchPos = nthash.get_pos() - 1;
+		assert(nthash.get_pos() >= 0 &&
+			nthash.get_pos() < (int)(seq.length() - k + 1));
+		maxMatchPos = nthash.get_pos();
 		maxMatchLen = matchCount;
 	}
 	if (maxMatchLen == 0)


### PR DESCRIPTION
* Was getting assertion error on mac
* The decrement was needed in Sealer with ABySS due to the use of an iteration over a range. But here, `nthash.get_pos()` will not go past the valid k-mer positions