### PR TITLE
Ensure GoldPolish subsampling is the same across different runs

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -35,11 +35,8 @@ get_random_indices(const size_t total_size, const size_t count)
   btllib::check_error(count > total_size,
                       FN_NAME + ": count cannot be larger than total_size.");
 
-  static std::mt19937 rng(0);
-
   std::vector<size_t> all_indices(total_size);
   std::iota(all_indices.begin(), all_indices.end(), 0);
-  std::shuffle(all_indices.begin(), all_indices.end(), rng);
 
   using advance_type = typename std::iterator_traits<
     decltype(all_indices.begin())>::difference_type;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -35,8 +35,7 @@ get_random_indices(const size_t total_size, const size_t count)
   btllib::check_error(count > total_size,
                       FN_NAME + ": count cannot be larger than total_size.");
 
-  static std::random_device dev;
-  static std::mt19937 rng(dev());
+  static std::mt19937 rng(0);
 
   std::vector<size_t> all_indices(total_size);
   std::iota(all_indices.begin(), all_indices.end(), 0);


### PR DESCRIPTION
Removed the shuffling of the indices to ensure subsampling always has the same outcome.